### PR TITLE
Traffic stats collection for DrumScript via github-repo-stats

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -1,0 +1,17 @@
+name: Repo Stats
+
+on:
+  schedule:
+    # Run daily at 23:00 UTC
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow manual runs
+
+jobs:
+  repo-stats:
+    name: repo-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@v1.5.2
+        with:
+          ghtoken: ${{ secrets.GHRS_GITHUB_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # **`DrumScript`**
 
 <!--date_created: sun-15-june-2025-->
-<!--date_edited: tues-07-july-2026--->
+<!--date_edited: tues-28-july-2026--->
 
 **Workflow Status**
 

--- a/repository_structure.md
+++ b/repository_structure.md
@@ -2,7 +2,7 @@
 ## `DrumScript` Python Package Structure
 
 <!--date_created: weds-25-oct-2025-->
-<!--date_edited: thurs-18-june-2026--->
+<!--date_edited: tues-28-july-2026--->
 
 ```markdown
 DrumScript/                          # Project root
@@ -11,7 +11,8 @@ DrumScript/                          # Project root
 │   │   ├── build_test.yml           # Tests whether the package is ready to be rebuilt and pushed to PyPi
 │   │   ├── docs.yml                 # Handles publishing of `DrumScript` documentation to GitHub Pages
 │   │   ├── publish.yml              # Handles publishing of the package to PyPi automatically
-│   │   ├── release.yml              # Manual dispatch from GitHub Actions UI (Actions → "Create Release" → Run workflow). You enter the version number, release type (Alpha/Beta/Stable), and an optional summary.
+│   │   ├── release.yml              # Manual dispatch from GitHub Actions UI (Actions → "Create Release" → Run workflow). Enter the version number, release type (Alpha/Beta/Stable), and an optional summary.
+│   │   ├── repo-stats.yml           # Daily (23:00 UTC) collection of repository traffic stats via [`jgehrcke/github-repo-stats`]|(https://github.com/jgehrcke/github-repo-stats). Data persisted to `DrumScript/github-repo-stats` branch. Not connected with source code to prevent bloat.
 │   │   └── tests.yml                # Handles tests on development branch and main to ensure they dont break when PR is merged
 │   ├── CODEOWNERS
 │   ├── ISSUE_TEMPLATE

--- a/tree.txt
+++ b/tree.txt
@@ -10,6 +10,7 @@
 │       ├── docs.yml
 │       ├── publish.yml
 │       ├── release.yml
+│       ├── repo-stats.yml
 │       ├── test_build.yml
 │       └── tests.yml
 ├── .gitignore
@@ -25,6 +26,7 @@
 ├── benchmarks
 │   ├── README.md
 │   └── run.py
+├── collect_code.sh
 ├── docs
 │   ├── FOLDER_STRUCTURE.txt
 │   ├── _templates
@@ -91,11 +93,13 @@
 │           ├── measure_kick_frequency.py
 │           └── measure_snare_frequency.py
 ├── public
-│   └── pyodideWorker.js
+│   └── drumscript-0.1.6-py3-none-any.whl
 ├── pyproject.toml
 ├── repository_structure.md
 ├── scripts
-│   └── run_tests.sh
+│   ├── pypi.sh
+│   ├── run_tests.sh
+│   └── update_public_wheel.sh
 ├── tests
 │   ├── README.md
 │   ├── conftest.py
@@ -120,4 +124,4 @@
 └── visuals
     └── tempogram.png
 
-25 directories, 96 files
+25 directories, 100 files


### PR DESCRIPTION
## Description
Adds a daily scheduled workflow to collect and persist repository traffic
statistics (views, clones, referrers, popular paths) using
`jgehrcke/github-repo-stats`. GitHub's Traffic API only retains 14 days
of data — this workflow captures daily snapshots to build an all-time
historical record.

Data is committed to a separate `github-repo-stats` branch automatically.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [x] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

Manual trigger via `workflow_dispatch` in the Actions tab.

## Checklist

- [x] All tests pass locally: `pytest -m "not slow"`
- [x] Code is formatted: `uv run ruff format .`
- [x] Linter is clean: `uv run ruff check .`
- [ ] I have added or updated tests to cover my changes (where applicable).
- [ ] I have added or updated docstrings for any changed public functions.
- [ ] I have updated `CHANGELOG.md` under `[Unreleased]`.
- [x] No `.ipynb` files are included in this PR.

## Screenshots / output (if relevant)

N/A — check the `github-repo-stats` branch after first successful run.