### PR TITLE
Release v0.2.1 — Python 3.13 install fix

### DIFF
--- a/docs/release_notes/0.2.1.md
+++ b/docs/release_notes/0.2.1.md
@@ -1,6 +1,6 @@
 # DrumScript v0.2.1 — Python 3.13 install fix
 
-*Release Date: [today's date]*
+*Release Date: 2026-08-21*
 
 > **Patch release.** Fixes a broken install experience on Python 3.13.
 
@@ -15,7 +15,7 @@ to install on Python 3.13 with a clear message rather than a confusing
 build failure.
 
 Python 3.13 support is planned once DrumScript migrates to numpy 2.x —
-tracked in [#XXX](link).
+tracked in #303.
 
 ## Fixes
 
@@ -27,4 +27,4 @@ tracked in [#XXX](link).
 pip install --upgrade drumscript
 ```
 
-Python 3.9, 3.10, 3.11, 3.12 users are unaffected.
+Python 3.9, 3.10, 3.11, 3.12 are unaffected.

--- a/docs/release_notes/0.2.1.md
+++ b/docs/release_notes/0.2.1.md
@@ -1,0 +1,30 @@
+# DrumScript v0.2.1 — Python 3.13 install fix
+
+*Release Date: [today's date]*
+
+> **Patch release.** Fixes a broken install experience on Python 3.13.
+
+## Highlights
+
+Python 3.13 installations of DrumScript v0.2.0 failed with an obscure
+`Compiler cc cannot compile programs` error, because pip fell back to
+building numpy 1.x from source (numpy 1.x has no Python 3.13 wheels on PyPI).
+
+v0.2.1 declares `requires-python = "<3.13,>=3.9"`, so pip cleanly refuses
+to install on Python 3.13 with a clear message rather than a confusing
+build failure.
+
+Python 3.13 support is planned once DrumScript migrates to numpy 2.x —
+tracked in [#XXX](link).
+
+## Fixes
+
+* `pyproject.toml`: `requires-python` lowered from `<3.14` to `<3.13`.
+
+## Upgrading
+
+```bash
+pip install --upgrade drumscript
+```
+
+Python 3.9, 3.10, 3.11, 3.12 users are unaffected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "A Python package to convert drum audio to sheet music."
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.13"
 authors = [
   { name="drumscript-admin", email="hello.drumscript@gmail.com" },
 ]


### PR DESCRIPTION
Patch release. See docs/release_notes/0.2.1.md and CHANGELOG.md for detail. Fixes broken `pip install drumscript` on Python 3.13.